### PR TITLE
Error message during install due to missing database tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Eclipse
+.project

--- a/mu-loader.php
+++ b/mu-loader.php
@@ -2,6 +2,12 @@
 
 function mu_loader_plugins_files()
 {
+    global $wpdb;
+    if ( $wpdb->get_var("SHOW TABLES LIKE '" . $wpdb->prefix . "options'") !== $wpdb->prefix . 'options' ) {
+      // Database tables have not been created yet
+      return array();
+    }
+    
     // Cache plugins
     $plugins = get_site_transient('mu_loader_plugins');
 


### PR DESCRIPTION
Thanks for your mu-loader. It works very nicely ;-)
I ran into the following issue: During a fresh wordpress install when running in Debug-Mode, an error shows up complaining about missing 'wp_options'-Table. 
Of course this is not critical, because there's no need for any tables at this point. But i think, it could be misleading or annoying for developers as well as for end users if configuration is set to 'debug' and it would be nice if this could be fixed.
I created a pull request that should fix the issue. 
It detects if 'wp_options'-table does exist in the database.
Another solution would be to detect if the script itself is run by the installer without need for another query.
Perhaps you'll have another idea to this... ;-)
Best regards, 
Rafael