### PR TITLE
add logic in case result of get_site_transient is an empty array

### DIFF
--- a/mu-loader.php
+++ b/mu-loader.php
@@ -22,7 +22,7 @@ function mu_loader_plugins_files()
         }
     }
 
-    if ($plugins === false) {
+    if ($plugins === false || $plugins === array()) {
         if (!function_exists('get_plugins')) {
             // get_plugins is not included by default
             require ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION
We had a case where plugins in mu-plugins were not loaded because the result of get_site_transient('mu_loader_plugins') was an empty array. We could not visit the plugins page to reset the transient because there was a fatal error thrown. The fatal error was thrown because one of our plugins relied upon a class that was in a plugin folder in the mu-plugins folder. Adding a check for $plugins === array() in the conditional checking if $plugins === false solved the problem.
